### PR TITLE
Accept filename as arguments

### DIFF
--- a/images/Readme.md
+++ b/images/Readme.md
@@ -15,13 +15,18 @@ Use at your own risk
 
 
 
+Usage:
+------
 
+Convert `img1.raw` to `img1.png`
+```
+./raw2png.sh img.raw
+```
 
-Please note:
-------------
-These scripts are not yet complete. To use them you will need to replace "IN" and "OUT" in the ffmpeg line with your raw file and png output or vice versa
-
-
+Convert `img2.png` to `img2.raw`
+```
+> ./png2raw.sh test.png
+```
 
 TODO:
 -----

--- a/images/Readme.md
+++ b/images/Readme.md
@@ -20,12 +20,12 @@ Usage:
 
 Convert `img1.raw` to `img1.png`
 ```
-./raw2png.sh img.raw
+$ ./raw2png.sh img.raw
 ```
 
 Convert `img2.png` to `img2.raw`
 ```
-> ./png2raw.sh test.png
+$ ./png2raw.sh test.png
 ```
 
 TODO:

--- a/images/png2raw.sh
+++ b/images/png2raw.sh
@@ -1,8 +1,5 @@
 #!/usr/bin/sh
-
-
-
-
-ffmpeg -i IN  -vf transpose=2 -f rawvideo -pix_fmt rgb565 -s 600x800 -y "OUT" < /dev/null
-
-cat extrabytes.bin >> OUT
+input=$1
+output=${input%.*}.raw
+ffmpeg -i $input -vf transpose=2 -f rawvideo -pix_fmt rgb565 -s 600x800 -y $output < /dev/null
+cat extrabytes.bin >> $output

--- a/images/raw2png.sh
+++ b/images/raw2png.sh
@@ -1,3 +1,6 @@
 #!/usr/bin/sh
-
-ffmpeg -f rawvideo -pix_fmt rgb565 -s 800x600 -i <(cat IN |head -c 960000) -vf transpose=1 -y OUT </dev/null
+input=$1
+output=${input%.*}.png
+cat $input | head -c 960000 > temp 
+ffmpeg -f rawvideo -pix_fmt rgb565 -s 800x600 -i temp -vf transpose=1 -y $output </dev/null
+rm temp


### PR DESCRIPTION
I tweaked the scripts so they take the image files as arguments, nothing fundamental was changed. I changed the readme accordingly. 

I have the impression that the extrabytes.bin is empty, as I try to view it with `xxd -b extrabytes.bin` and nothing appears. That affects the inverse reconstruction I believe.
